### PR TITLE
fix an order issue in code/scripts, minor edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 # Data files
 data/ds005/
+data/templates
 results/
 
 # Byte-compiled / optimized / DLL files

--- a/code/Makefile
+++ b/code/Makefile
@@ -16,10 +16,10 @@ coverage:
 all: 
 	cd scripts && make histograms
 	cd scripts && make smoothing
+	cd scripts && make diagnostics
 	cd scripts && make glm
 	cd scripts && make glmstandard
 	cd scripts && make logistic
-	cd scripts && make diagnostics
 	cd scripts && make heatmap
 	cd scripts && make bncorrelates
 	cd scripts && make mixedmodel

--- a/code/README.md
+++ b/code/README.md
@@ -46,5 +46,5 @@ be found in their respective READMEs.
 The exhaustive results, including all figures and intermediate results files, 
 are saved in a local, untracked directory `project-theta/results` initailized 
 by running the make command `make resultfolder` from `project-theta` directory. 
-All paper figures are saved in `project-alpha/paper/figures`, which also caches the 
+All paper figures are saved in `project-theta/paper/figures`, which also caches the 
 figures required slides. These figures can be updated by running `make paperfig`.

--- a/code/scripts/Makefile
+++ b/code/scripts/Makefile
@@ -4,10 +4,9 @@ histograms:
 	python find_mask_threshold.py
 
 diagnostics:
-	python graph_lindiag_script.py
 	python findoutlier.py
 	python graphoutlier.py
-
+	python graph_lindiag_script.py
 logistic:
 	python logistic.py
 

--- a/code/scripts/README.md
+++ b/code/scripts/README.md
@@ -2,8 +2,8 @@
 
 These are the scripts used to run our analyses and build our figures.
 Run the following make commands for running the individual analysis. Note that 
-`logistic`, `glm`, and `glmstandard` must come *before* `mixedeffect`, `heatmap`,
-and `bncorrelates`.
+`diagnostics` must come *before* `glm` and that `logistic`, `glm`, and 
+`glmstandard` must come *before* `mixedeffect`, `heatmap`,and `bncorrelates`.
 
 - `make histograms`: Generates preliminary histograms of all subjects, all runs
 for all data in order to identify masking thresholds of smoothed non-standardize
@@ -14,7 +14,7 @@ of non-standardized ds005 BOLD data.
 - `make smoothing`: Generates smoothed graphs of BOLD slices for comparison.
 - `make glm`: Performs smoothing, convolution and linear regression after of all
  subjects using the non-standardized ds005 data. Saves beta and t values. 
-**Warning**: This may take up to 45 minutes.
+**Warning**: This may take up to 45 minutes.*Run after `make diagnostics`*
 - `make glmstandard`: Performs the same procedure as `make glm`, but with the 
 standardized ds005 data (with mni template). **Warning**: This may take several 
 hours.

--- a/code/scripts/graph_lindiag_script.py
+++ b/code/scripts/graph_lindiag_script.py
@@ -43,7 +43,7 @@ for i in range(2,3):
         direct='ds005/sub0'+str(i).zfill(2)+'/BOLD/task001_run00'+`j`+'/'
         boldname = direct+'bold.nii.gz'
         img=nib.load(boldname)
-        data=img.get_data()
+        data=img.get_data().astype(float)
         data=smooth_spatial(data)
         run = j
         behav_cond = 'ds005/sub0'+str(i).zfill(2)+'/behav/task001_run00'+`j`+'/behavdata.txt'

--- a/code/scripts/neural_behavial_plot.py
+++ b/code/scripts/neural_behavial_plot.py
@@ -14,7 +14,7 @@ import nibabel as nib
 sys.path.append('../utils/functions')
 from sig_region import stat_region
 sys.path.append('../utils/graphing')
-from neural_behavior import plot_neur_beh
+from plot_neural_behavior import plot_neur_beh
 
 
 pgain = np.loadtxt("../../results/texts/pgain.txt")


### PR DESCRIPTION
So graph_lin_diagnostics is saving res_fitted_log and res_fitted to the paper/figures directory and not the results/figures directory. 

We want to fix that right?

Also, the graph looks a little weird to me now. 

![res_fitted](https://cloud.githubusercontent.com/assets/14049646/11790520/1ffb4e20-a251-11e5-8ab2-8ddd0efb3519.png)
